### PR TITLE
Align Custom APNS to Bliss vs Lineage

### DIFF
--- a/tools/custom_apns.py
+++ b/tools/custom_apns.py
@@ -21,7 +21,7 @@ from xml.dom.minidom import parseString
 def main(argv):
     reload(sys)
     sys.setdefaultencoding('utf8')
-    original_file = 'vendor/lineage/prebuilt/common/etc/apns-conf.xml'
+    original_file = 'vendor/bliss/prebuilt/common/etc/apns-conf.xml'
 
     if len(argv) == 3:
         output_file_path = argv[1]


### PR DESCRIPTION
Build is failing for folks using a custom apns file in their device trees.  Simple fix, vendor path was set to lineage instead of bliss =)