### PR TITLE
vendor: common: Exclude ntfs-3g from artifact path requirement

### DIFF
--- a/config/common.mk
+++ b/config/common.mk
@@ -117,6 +117,19 @@ PRODUCT_MINIMIZE_JAVA_DEBUG_INFO := true
 # Disable vendor restrictions
 PRODUCT_RESTRICT_VENDOR_FILES := false
 
+# Filesystems tools
+PRODUCT_PACKAGES += \
+    fsck.ntfs \
+    mkfs.ntfs \
+    mount.ntfs
+
+PRODUCT_ARTIFACT_PATH_REQUIREMENT_ALLOWED_LIST += \
+    system/bin/fsck.ntfs \
+    system/bin/mkfs.ntfs \
+    system/bin/mount.ntfs \
+    system/%/libfuse-lite.so \
+    system/%/libntfs-3g.so
+
 # Storage manager
 PRODUCT_SYSTEM_DEFAULT_PROPERTIES += \
     ro.storage_manager.enabled=true


### PR DESCRIPTION
Change-Id: I6253ac0b326f86ba7fd78f6babb9ee2242ba9133

This fixes the annoying NTFS bug we had for quite a long time!